### PR TITLE
Alternative turn-off command for android tv

### DIFF
--- a/braviapsk/sony_bravia_psk.py
+++ b/braviapsk/sony_bravia_psk.py
@@ -336,7 +336,7 @@ class BraviaRC(object):
         self.send_req_ircc(self.get_command_code('PowerOff'))
 
     def turn_off_command(self):
-        """Turn off media player using the rest-api"""
+        """Turn off media player using the rest-api for Android TV."""
         self.bravia_req_json("sony/system", self._jdata_build("setPowerStatus", {"status": False}))
 
     def volume_up(self):

--- a/braviapsk/sony_bravia_psk.py
+++ b/braviapsk/sony_bravia_psk.py
@@ -335,6 +335,10 @@ class BraviaRC(object):
         """Turn off media player."""
         self.send_req_ircc(self.get_command_code('PowerOff'))
 
+    def turn_off_command(self):
+        """Turn off media player using the rest-api"""
+        self.bravia_req_json("sony/system", self._jdata_build("setPowerStatus", {"status": False}))
+
     def volume_up(self):
         """Volume up the media player."""
         self.send_req_ircc(self.get_command_code('VolumeUp'))

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='pySonyBraviaPSK',
-    version='0.1.8',
+    version='0.1.9',
     description='Library for Sony Bravia TVs with Pre-Shared Key option',
     url='https://github.com/gerard33/sony_bravia_psk',
     maintainer='Gerard',


### PR DESCRIPTION
Since the Oreo Update the IRCC-command is unreliable. This seems to be an issue on the TV‘s side, since the issue can be replicated via rest-calls.

This change implements an additional power-off command similar to the power-on call.