### PR TITLE
Add getCurrentExternalInputsStatus

### DIFF
--- a/braviapsk/sony_bravia_psk.py
+++ b/braviapsk/sony_bravia_psk.py
@@ -314,6 +314,16 @@ class BraviaRC(object):
             return_value['gateway'] = network_content_data[0]['gateway']
         return return_value
 
+    def get_current_external_input_status(self):
+        """Get current external input status."""
+        return_value = {}
+        resp = self.bravia_req_json(
+            "sony/avContent", self._jdata_build("getCurrentExternalInputsStatus", None)
+        )
+        if resp is not None and not resp.get("error"):
+            return_value = resp.get("result")[0]
+        return return_value
+
     def set_volume_level(self, volume):
         """Set volume level, range 0..1."""
         # API expects string int value within 0..100 range.

--- a/braviapsk/sony_bravia_psk.py
+++ b/braviapsk/sony_bravia_psk.py
@@ -316,9 +316,11 @@ class BraviaRC(object):
 
     def get_current_external_input_status(self):
         """Get current external input status."""
-        return_value = {}
+        return_value = []
         resp = self.bravia_req_json(
-            "sony/avContent", self._jdata_build("getCurrentExternalInputsStatus", None)
+            "sony/avContent",
+            self._jdata_build("getCurrentExternalInputsStatus", None),
+            log_errors=False,
         )
         if resp is not None and not resp.get("error"):
             return_value = resp.get("result")[0]


### PR DESCRIPTION
In support of https://github.com/gerard33/sony_bravia_psk/issues/15

dd the ability to retrieve information from the endpoint sony/avContent with method "getCurrentExternalInputsStatus". This pulls back Information such as:

{ "uri": "extInput:hdmi?port=1", "title": "HDMI 1", "connection": true, "label": "Sky Q", "icon": "meta:hdmi", "status": "false" },

I do see on my TV which is a few years old that this will return 500 status code when my HDMI 1 receives input from my Sky box, but until that point it provides information on any label the user may have provided.